### PR TITLE
fix addon url param

### DIFF
--- a/hrobot/order.go
+++ b/hrobot/order.go
@@ -373,6 +373,6 @@ type OrderServerOpts struct {
 	Arch     string `url:"arch"`
 	Lang     string `url:"lang"`
 	Comment  string `url:"comment"`
-	Addons   string `url:"addons[]"`
+	Addons   string `url:"addon[]"`
 	Test     bool   `url:"test"`
 }


### PR DESCRIPTION
https://robot.hetzner.com/doc/webservice/en.html#post-order-server-transaction

was wondering why my servers weren't coming up with ipv4 and traced it down to this :)